### PR TITLE
simplify DSVParser with just Delimiter and Escape

### DIFF
--- a/godsv.go
+++ b/godsv.go
@@ -8,38 +8,35 @@ import (
 type Row []string
 
 type DSVParser struct {
-	Delimiter     string
-	DelimiterRune rune
-	Escape        string
-	EscapeRune    rune
+	Delimiter    rune
+	Escape       rune
 }
 
 // Delimiter separate values from each other. Delimiter is traditionally a colon, escape with a backslash
-const defaultDelimiter = ":"
-
-// DelimiterRune is a delimiter as a rune
-const defaultDelimiterRune = ':'
+const defaultDelimiter = ':'
 
 // Escape is the character use for escaping delimiter in values
-const defaultEscape = "\\"
-
-// EscapeRune is an escape as a rune
-const defaultEscapeRune = '\\'
+const defaultEscape = '\\'
 
 func New() DSVParser {
-	return DSVParser{defaultDelimiter, defaultDelimiterRune, defaultEscape, defaultEscapeRune}
+	return DSVParser{defaultDelimiter, defaultEscape}
 }
 
 // Marshal encode a Row into a line in DSV file
 func (dsv DSVParser) Marshal(row Row) string {
 	tempRow := make(Row, len(row))
+	escape := string(dsv.Escape)
+	escapedEscape := escape + escape
+	delimiter := string(dsv.Delimiter)
+	escapedDelimiter := escape + delimiter
+
 	for k, v := range row {
 		tempRow[k] = v
 		// escape special characters (Delimiter and Escape itself)
-		tempRow[k] = strings.Replace(v, dsv.Escape, dsv.Escape+dsv.Escape, -1)
-		tempRow[k] = strings.Replace(tempRow[k], dsv.Delimiter, dsv.Escape+dsv.Delimiter, -1)
+		tempRow[k] = strings.Replace(v, escape, escapedEscape, -1)
+		tempRow[k] = strings.Replace(tempRow[k], delimiter, escapedDelimiter, -1)
 	}
-	return strings.Join(tempRow, dsv.Delimiter)
+	return strings.Join(tempRow, delimiter)
 }
 
 // Unmarshal decode a line in DSV file into a Row
@@ -63,9 +60,9 @@ func (dsv DSVParser) cut(line string) (value string, leftover string) {
 		switch {
 		case literal:
 			literal = false
-		case v == dsv.EscapeRune:
+		case v == dsv.Escape:
 			literal = true
-		case v == dsv.DelimiterRune:
+		case v == dsv.Delimiter:
 			leftover = line[k+1:]
 			ve = k
 			done = true
@@ -90,10 +87,10 @@ func (dsv DSVParser) count(line string) int {
 		case literal:
 			literal = false
 			continue
-		case v == dsv.EscapeRune:
+		case v == dsv.Escape:
 			literal = true
 			continue
-		case v == dsv.DelimiterRune:
+		case v == dsv.Delimiter:
 			result++
 		default:
 			continue
@@ -105,7 +102,12 @@ func (dsv DSVParser) count(line string) int {
 
 // clean escape out of a row's value
 func (dsv DSVParser) clean(value string) string {
-	result := strings.Replace(value, dsv.Escape+dsv.Delimiter, dsv.Delimiter, -1)
-	result = strings.Replace(result, dsv.Escape+dsv.Escape, dsv.Escape, -1)
+	escape := string(dsv.Escape)
+	escapedEscape := escape + escape
+	delimiter := string(dsv.Delimiter)
+	escapedDelimiter := escape + delimiter
+
+	result := strings.Replace(value, escapedDelimiter, delimiter, -1)
+	result = strings.Replace(result, escapedEscape, escape, -1)
 	return string(result)
 }

--- a/godsv_test.go
+++ b/godsv_test.go
@@ -42,8 +42,7 @@ func ExampleCustomMarshal() {
 		"ef\\gh",
 	}
 	dsv := New()
-	dsv.Delimiter = ","
-	dsv.DelimiterRune = ','
+	dsv.Delimiter = ','
 	fmt.Println(dsv.Marshal(sample))
 	fmt.Println(strings.Join(sample, " "))
 	// Output: abc,def,ghk,,ab\,cd,ef\\gh
@@ -53,8 +52,7 @@ func ExampleCustomMarshal() {
 func ExampleCustomUnmarshal() {
 	sample := "abc,def,ghk,,ab\\,cd,ef\\\\gh"
 	dsv := New()
-	dsv.Delimiter = ","
-	dsv.DelimiterRune = ','
+	dsv.Delimiter = ','
 	result := dsv.Unmarshal(sample)
 	fmt.Println(strings.Join(result, " "))
 	fmt.Println(sample)


### PR DESCRIPTION
… getting rid of DelimiterRune and EscapeRune.
I'll be the first one to do this:

```
dsv := godsv.New()
dsv.Delimiter = "|"
result := dsv.Unmarshal(sample)
```

and spend hours wondering why my code doesn't work LOL
